### PR TITLE
Add Celery-based async scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,54 @@
+# Dumping Detector Backend
+
+## Ejecución de tareas en segundo plano
+
+Este proyecto utiliza [Celery](https://docs.celeryq.dev/) para ejecutar el
+scraper de forma asíncrona.
+
+### Instalación
+
+```bash
+pip install -r requirements.txt
+```
+
+### Levantar los servicios
+
+1. Inicia un broker y backend de resultados, por ejemplo Redis:
+
+   ```bash
+   redis-server
+   ```
+
+2. Ejecuta un worker de Celery:
+
+   ```bash
+   celery -A tasks worker --loglevel=info
+   ```
+
+3. Inicia la aplicación Flask:
+
+   ```bash
+   python app.py
+   ```
+
+### Uso de los endpoints
+
+1. Encola una tarea de scraping:
+
+   ```bash
+   curl -X POST http://localhost:5000/api/scrape \
+        -H "Content-Type: application/json" \
+        -d '{"producto": "zapatos", "plataforma": "aliexpress"}'
+   ```
+
+   La respuesta contendrá un `task_id`.
+
+2. Consulta el estado y resultado de la tarea:
+
+   ```bash
+   curl http://localhost:5000/api/resultado/<task_id>
+   ```
+
+   Cuando la tarea haya finalizado, el objeto resultante incluirá los
+   productos encontrados y el nombre del archivo CSV generado.
+

--- a/app.py
+++ b/app.py
@@ -1,20 +1,7 @@
 from flask import Flask, request, jsonify, send_file
 from flask_cors import CORS
 
-from scraper.aliexpress_scraper import obtener_productos_aliexpress
-from scraper.temu_scraper import obtener_productos_temu
-from scraper.alibaba_scraper import obtener_productos_alibaba
-from scraper.madeinchina_scraper import obtener_productos_made_in_china
-
-import pandas as pd
-import os
-
-SCRAPERS = {
-    "aliexpress": (obtener_productos_aliexpress, "productos_aliexpress.csv"),
-    "temu": (obtener_productos_temu, "productos_temu.csv"),
-    "alibaba": (obtener_productos_alibaba, "productos_alibaba.csv"),
-    "madeinchina": (obtener_productos_made_in_china, "productos_madeinchina.csv"),
-}
+from tasks import scrapear
 
 app = Flask(__name__)
 CORS(app)  # Permitir peticiones desde el frontend React
@@ -35,25 +22,18 @@ def scrape():
             ),
             400,
         )
+    task = scrapear.delay(producto, plataforma)
+    return jsonify({"task_id": task.id}), 202
 
-    scraper_info = SCRAPERS.get(plataforma)
-    if scraper_info is None:
-        return (
-            jsonify({"success": False, "message": "Plataforma no soportada."}),
-            400,
-        )
 
-    scraper_func, csv_name = scraper_info
-    productos = scraper_func(producto)
-    archivo_csv = os.path.join("data", csv_name)
-
-    if productos:
-        os.makedirs("data", exist_ok=True)
-        df = pd.DataFrame(productos)
-        df.to_csv(archivo_csv, index=False, encoding="utf-8-sig")
-        return jsonify({"success": True, "productos": productos})
-
-    return jsonify({"success": False, "message": "No se encontraron productos."})
+@app.route("/api/resultado/<task_id>")
+def resultado(task_id):
+    task = scrapear.AsyncResult(task_id)
+    if task.state == "PENDING":
+        return jsonify({"state": task.state})
+    if task.state == "SUCCESS":
+        return jsonify({"state": task.state, **task.result})
+    return jsonify({"state": task.state, "message": str(task.info)}), 400
 
 @app.route("/api/descargar/<nombre>")
 def descargar(nombre):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ selenium
 beautifulsoup4
 pandas
 webdriver-manager
+celery[redis]

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,46 @@
+from celery import Celery
+import os
+import pandas as pd
+
+from scraper.aliexpress_scraper import obtener_productos_aliexpress
+from scraper.temu_scraper import obtener_productos_temu
+from scraper.alibaba_scraper import obtener_productos_alibaba
+from scraper.madeinchina_scraper import obtener_productos_made_in_china
+
+
+celery_app = Celery(
+    "tasks",
+    broker=os.environ.get("CELERY_BROKER_URL", "redis://localhost:6379/0"),
+    backend=os.environ.get("CELERY_RESULT_BACKEND", "redis://localhost:6379/0"),
+)
+
+
+SCRAPERS = {
+    "aliexpress": (obtener_productos_aliexpress, "productos_aliexpress.csv"),
+    "temu": (obtener_productos_temu, "productos_temu.csv"),
+    "alibaba": (obtener_productos_alibaba, "productos_alibaba.csv"),
+    "madeinchina": (
+        obtener_productos_made_in_china,
+        "productos_madeinchina.csv",
+    ),
+}
+
+
+@celery_app.task(name="scrapear")
+def scrapear(producto: str, plataforma: str):
+    scraper_info = SCRAPERS.get(plataforma)
+    if scraper_info is None:
+        return {"success": False, "message": "Plataforma no soportada."}
+
+    scraper_func, csv_name = scraper_info
+    productos = scraper_func(producto)
+    archivo_csv = os.path.join("data", csv_name)
+
+    if productos:
+        os.makedirs("data", exist_ok=True)
+        df = pd.DataFrame(productos)
+        df.to_csv(archivo_csv, index=False, encoding="utf-8-sig")
+        return {"success": True, "productos": productos, "archivo": csv_name}
+
+    return {"success": False, "message": "No se encontraron productos."}
+


### PR DESCRIPTION
## Summary
- add Celery dependency
- queue scraping tasks and expose result endpoint
- document how to run worker and check results

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc8ac6039c83328ca226186ab3b1c9