### PR TITLE
Add environment-based configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ scraper de forma asíncrona.
 pip install -r requirements.txt
 ```
 
+### Variables de entorno
+
+Antes de iniciar la aplicación o los workers, define las siguientes variables de entorno:
+
+- `DEBUG`: activa el modo de depuración de Flask (`True` o `False`, por defecto `False`).
+- `CELERY_BROKER_URL`: URL del broker de mensajes para Celery.
+- `CELERY_RESULT_BACKEND`: URL del backend de resultados para Celery.
+- `ALLOWED_ORIGINS`: lista separada por comas de dominios permitidos para CORS (usa `*` para permitir todos).
+
 ### Levantar los servicios
 
 1. Inicia un broker y backend de resultados, por ejemplo Redis:

--- a/app.py
+++ b/app.py
@@ -1,10 +1,12 @@
 from flask import Flask, request, jsonify, send_file
 from flask_cors import CORS
 
+from config import Config
 from tasks import scrapear
 
 app = Flask(__name__)
-CORS(app)  # Permitir peticiones desde el frontend React
+app.config.from_object(Config)
+CORS(app, origins=app.config["ALLOWED_ORIGINS"])  # Permitir peticiones desde dominios permitidos
 
 @app.route("/api/scrape", methods=["POST"])
 def scrape():
@@ -41,4 +43,4 @@ def descargar(nombre):
     return send_file(path, as_attachment=True)
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    app.run(debug=app.config["DEBUG"])

--- a/config.py
+++ b/config.py
@@ -1,0 +1,18 @@
+import os
+
+
+class Config:
+    """Application configuration loaded from environment variables."""
+
+    DEBUG = os.environ.get("DEBUG", "false").lower() in {"1", "true", "t", "yes"}
+    CELERY_BROKER_URL = os.environ.get(
+        "CELERY_BROKER_URL", "redis://localhost:6379/0"
+    )
+    CELERY_RESULT_BACKEND = os.environ.get(
+        "CELERY_RESULT_BACKEND", "redis://localhost:6379/0"
+    )
+    _origins = os.environ.get("ALLOWED_ORIGINS", "*")
+    if _origins == "*":
+        ALLOWED_ORIGINS = "*"
+    else:
+        ALLOWED_ORIGINS = [origin.strip() for origin in _origins.split(",") if origin.strip()]

--- a/tasks.py
+++ b/tasks.py
@@ -1,17 +1,21 @@
 from celery import Celery
 import os
 import pandas as pd
+from flask import Flask
 
+from config import Config
 from scraper.aliexpress_scraper import AliExpressScraper
 from scraper.temu_scraper import TemuScraper
 from scraper.alibaba_scraper import AlibabaScraper
 from scraper.madeinchina_scraper import MadeInChinaScraper
 
+flask_app = Flask(__name__)
+flask_app.config.from_object(Config)
 
 celery_app = Celery(
     "tasks",
-    broker=os.environ.get("CELERY_BROKER_URL", "redis://localhost:6379/0"),
-    backend=os.environ.get("CELERY_RESULT_BACKEND", "redis://localhost:6379/0"),
+    broker=flask_app.config["CELERY_BROKER_URL"],
+    backend=flask_app.config["CELERY_RESULT_BACKEND"],
 )
 
 SCRAPERS = {


### PR DESCRIPTION
## Summary
- centralize Flask and Celery settings in new Config class
- load configuration in application and worker, including CORS and debug flag
- document required environment variables

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'scraper')*

------
https://chatgpt.com/codex/tasks/task_e_68bc93fbef808332a3a6581eb4206f4e