### PR TITLE
Use WebDriverWait instead of sleep in scrapers

### DIFF
--- a/scraper/alibaba_scraper.py
+++ b/scraper/alibaba_scraper.py
@@ -1,7 +1,9 @@
 from bs4 import BeautifulSoup
 from datetime import datetime
 import re
-import time
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
 from .base import BaseScraper
 
 
@@ -28,7 +30,9 @@ class AlibabaScraper(BaseScraper):
                 f"https://www.alibaba.com/trade/search?SearchText={producto.replace(' ', '+')}&page={pagina}"
             )
             self.driver.get(url)
-            time.sleep(10)
+            WebDriverWait(self.driver, 10).until(
+                EC.presence_of_element_located((By.CSS_SELECTOR, "div.card-info.gallery-card-layout-info"))
+            )
             self.scroll(3)
 
             soup = BeautifulSoup(self.driver.page_source, "html.parser")

--- a/scraper/aliexpress_scraper.py
+++ b/scraper/aliexpress_scraper.py
@@ -1,7 +1,9 @@
 from bs4 import BeautifulSoup
 from datetime import datetime
 import re
-import time
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
 from .base import BaseScraper
 
 
@@ -15,7 +17,9 @@ class AliExpressScraper(BaseScraper):
             )
             print(f"🌀 Cargando AliExpress: Página {page}")
             self.driver.get(url)
-            time.sleep(10)
+            WebDriverWait(self.driver, 10).until(
+                EC.presence_of_element_located((By.CSS_SELECTOR, "div.jr_js"))
+            )
             self.scroll(6)
 
             soup = BeautifulSoup(self.driver.page_source, "html.parser")

--- a/scraper/base.py
+++ b/scraper/base.py
@@ -1,9 +1,10 @@
 import os
-import time
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.chrome.service import Service
 from webdriver_manager.chrome import ChromeDriverManager
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
 
 
 class BaseScraper:
@@ -22,12 +23,17 @@ class BaseScraper:
         os.makedirs(self.data_dir, exist_ok=True)
 
     def scroll(self, times: int = 5, delay: float = 2):
-        """Scroll the current page several times."""
+        """Scroll the current page several times waiting for new content."""
         for _ in range(times):
+            prev_height = self.driver.execute_script(
+                "return document.body.scrollHeight"
+            )
             self.driver.execute_script(
                 "window.scrollTo(0, document.body.scrollHeight);"
             )
-            time.sleep(delay)
+            WebDriverWait(self.driver, delay).until(
+                lambda d: d.execute_script("return document.body.scrollHeight") > prev_height
+            )
 
     def parse(self, *args, **kwargs):
         """Method to be implemented by subclasses."""

--- a/scraper/madeinchina_scraper.py
+++ b/scraper/madeinchina_scraper.py
@@ -1,6 +1,8 @@
 from bs4 import BeautifulSoup
 from datetime import datetime
-import time
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
 from .base import BaseScraper
 
 
@@ -15,7 +17,9 @@ class MadeInChinaScraper(BaseScraper):
             )
             print(f"🌐 Visitando página {pagina} - {url}")
             self.driver.get(url)
-            time.sleep(8)
+            WebDriverWait(self.driver, 8).until(
+                EC.presence_of_element_located((By.CSS_SELECTOR, "div.list-node-content"))
+            )
             self.scroll(3)
 
             soup = BeautifulSoup(self.driver.page_source, "html.parser")

--- a/scraper/temu_scraper.py
+++ b/scraper/temu_scraper.py
@@ -1,6 +1,8 @@
 from bs4 import BeautifulSoup
 from datetime import datetime
-import time
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
 from .base import BaseScraper
 
 
@@ -8,7 +10,9 @@ class TemuScraper(BaseScraper):
     def parse(self, producto: str):
         url = f"https://www.temu.com/pe/search.html?search_key={producto.replace(' ', '%20')}"
         self.driver.get(url)
-        time.sleep(10)
+        WebDriverWait(self.driver, 10).until(
+            EC.presence_of_element_located((By.CSS_SELECTOR, "div._6q6qVUF5._1UrrHYym"))
+        )
         self.scroll(5)
 
         soup = BeautifulSoup(self.driver.page_source, "html.parser")


### PR DESCRIPTION
## Summary
- replace `time.sleep` calls with `WebDriverWait` and explicit element waits across scrapers
- add Selenium support imports and dynamic scroll waiting

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd7bc6ba50833296fd2d222a0b1697