### PR TITLE
Add flask-cors dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ beautifulsoup4
 pandas
 webdriver-manager
 celery[redis]
+flask-cors


### PR DESCRIPTION
## Summary
- add flask-cors dependency to requirements

## Testing
- `pip install -r requirements.txt` (fails: Could not find a version that satisfies the requirement flask-cors)
- `pytest` (fails: ModuleNotFoundError: No module named 'scraper')
- `docker build -t mi_app .` (fails: command not found: docker)
- `docker run --name web -p 5000:5000 mi_app` (fails: command not found: docker)

------
https://chatgpt.com/codex/tasks/task_e_68bd8fa5029083328331c4fe2fc00bbb