### PR TITLE
Return detailed task info

### DIFF
--- a/app.py
+++ b/app.py
@@ -49,10 +49,13 @@ def scrape():
 def resultado(task_id):
     task = scrapear.AsyncResult(task_id)
     if task.state == "PENDING":
-        return jsonify({"state": task.state})
+        return jsonify({"state": task.state}), 200
     if task.state == "SUCCESS":
-        return jsonify({"state": task.state, **task.result})
-    return jsonify({"state": task.state, "message": str(task.info)}), 400
+        return jsonify({"state": task.state, **task.result}), 200
+    response = {"state": task.state, "message": str(task.info)}
+    if task.state == "FAILURE":
+        response["traceback"] = task.traceback
+    return jsonify(response), 200
 
 @app.route("/api/descargar/<nombre>")
 def descargar(nombre):


### PR DESCRIPTION
## Summary
- Always return HTTP 200 with task state information
- Include failure message and optional traceback for debugging

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd9a3e59008332bba77929e1dab7d3