### PR TITLE
Manejar errores de scraping en tareas

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -38,7 +38,11 @@ def scrapear(producto: str, plataforma: str):
     scraper_cls, csv_name = scraper_info
     logging.info("Ejecutando scraper %s para %s", plataforma, producto)
     scraper = scraper_cls()
-    productos = scraper.parse(producto)
+    try:
+        productos = scraper.parse(producto)
+    except Exception as e:
+        logging.exception("Error al ejecutar scraper")
+        return {"success": False, "message": str(e)}
     archivo_csv = os.path.join("data", csv_name)
 
     if productos:


### PR DESCRIPTION
## Resumen
- Captura excepciones al ejecutar `scraper.parse` en la tarea `scrapear`.
- Registra el error con `logging.exception` y devuelve un mensaje con la causa.

## Testing
- `PYTHONPATH=$PWD pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd9a3fa09c8332a9c9818c062709a2