### PR TITLE
Add API endpoint tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,54 @@
+import json
+from unittest.mock import patch
+
+import pytest
+
+from app import app
+from tasks import scrapear
+
+
+@pytest.fixture
+def client():
+    app.config["TESTING"] = True
+    with app.test_client() as client:
+        yield client
+
+
+def dummy_run(producto, plataforma):
+    return {"success": True, "productos": [], "archivo": "file.csv"}
+
+
+def test_scrape_endpoint_returns_task_id(client):
+    with patch("tasks.scrapear.run", side_effect=dummy_run):
+        with patch("tasks.scrapear.delay") as mock_delay:
+            mock_delay.side_effect = lambda *a, **kw: scrapear.apply(args=a, kwargs=kw)
+            response = client.post(
+                "/api/scrape", json={"producto": "test", "plataforma": "temu"}
+            )
+    assert response.status_code == 202
+    data = response.get_json()
+    assert "task_id" in data
+    assert data["task_id"]
+
+
+def test_resultado_endpoint_success(client):
+    with patch("tasks.scrapear.run", side_effect=dummy_run):
+        result = scrapear.apply(args=("test", "temu"))
+    with patch("tasks.scrapear.AsyncResult", return_value=result):
+        response = client.get(f"/api/resultado/{result.id}")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["state"] == "SUCCESS"
+    assert data["success"] is True
+    assert data["productos"] == []
+    assert data["archivo"] == "file.csv"
+
+
+def test_scrape_endpoint_missing_params(client):
+    response = client.post(
+        "/api/scrape", json={"producto": "test"}
+    )
+    assert response.status_code == 400
+    data = response.get_json()
+    assert data["success"] is False
+    assert "message" in data


### PR DESCRIPTION
## Summary
- add pytest tests for `/api/scrape` and `/api/resultado/<task_id>`
- cover success path, missing parameters, and result retrieval

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd9a48903c83329fe4d57d42011b7c