### PR TITLE
Expose Flask server on all interfaces

### DIFF
--- a/app.py
+++ b/app.py
@@ -69,4 +69,4 @@ def descargar(nombre):
     return send_file(path, as_attachment=True)
 
 if __name__ == "__main__":
-    app.run(debug=app.config["DEBUG"])
+    app.run(host="0.0.0.0", debug=app.config["DEBUG"])


### PR DESCRIPTION
## Summary
- Listen on all network interfaces by running the Flask app with host `0.0.0.0`.

## Testing
- `pytest -q`
- `python app.py` (terminated) to verify the server binds to all addresses


------
https://chatgpt.com/codex/tasks/task_e_68bda8aca388833291753febaeb459f1