### PR TITLE
Document Python and Celery versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,18 @@ scraper de forma asíncrona.
 
 ### Instalación
 
-Requiere Python 3.10–3.12. Celery 5.5 no funciona en Python 3.13.
+Requiere Python 3.10–3.12 y Celery 5.3.4. Celery 5.5 no funciona en Python 3.13.
 
 ```bash
 pip install -r requirements.txt
+```
+
+### Docker (opcional)
+
+Para evitar problemas de compatibilidad, puedes ejecutar el proyecto con Docker (Python 3.10):
+
+```bash
+docker-compose up --build
 ```
 
 ### Variables de entorno

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ selenium
 beautifulsoup4
 pandas
 webdriver-manager
-celery[redis]==5.3.4
+celery[redis]==5.3.4  # pinned for Python 3.10–3.12 compatibility
 flask-cors


### PR DESCRIPTION
## Summary
- Specify Python 3.10–3.12 and Celery 5.3.4 requirements
- Add optional Docker instructions using Python 3.10
- Pin Celery dependency to version 5.3.4

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdab5f86b08332912490fac5a48ae2