### PR TITLE
Configure Chromium for Selenium scrapers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM python:3.10
 WORKDIR /app
 COPY . .
+
+RUN apt-get update && \
+    apt-get install -y chromium-driver chromium && \
+    rm -rf /var/lib/apt/lists/*
+
 RUN pip install -r requirements.txt
 CMD ["python", "app.py"]

--- a/scraper/base.py
+++ b/scraper/base.py
@@ -1,6 +1,5 @@
 import os
 from selenium import webdriver
-from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.chrome.service import Service
 from webdriver_manager.chrome import ChromeDriverManager
 from selenium.webdriver.support.ui import WebDriverWait
@@ -10,10 +9,10 @@ from selenium.webdriver.support import expected_conditions as EC
 class BaseScraper:
     """Common setup for Selenium based scrapers."""
 
-    def __init__(self, headless: bool = False, data_dir: str = "data"):
-        options = Options()
-        if headless:
-            options.add_argument("--headless")
+    def __init__(self, data_dir: str = "data"):
+        options = webdriver.ChromeOptions()
+        options.binary_location = "/usr/bin/chromium"
+        options.add_argument("--headless")
         options.add_argument("--disable-gpu")
 
         service = Service(ChromeDriverManager().install())


### PR DESCRIPTION
## Summary
- Install Chromium and its driver in Dockerfile
- Set Chrome options to use headless Chromium in base scraper

## Testing
- `pytest`
- `docker build -t mi_app .` *(fails: command not found: docker)*
- `docker run --name web -p 5000:5000 mi_app` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb75e728083329dc37eb6a1a3877d