### PR TITLE
Run containers as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,18 @@
 FROM python:3.10
-WORKDIR /app
-COPY . .
 
 RUN apt-get update && \
     apt-get install -y chromium-driver chromium && \
     rm -rf /var/lib/apt/lists/*
 
-RUN pip install -r requirements.txt
+RUN useradd -ms /bin/bash appuser
+
+WORKDIR /app
+COPY . .
+
+RUN pip install -r requirements.txt && \
+    mkdir -p logs cache && \
+    chown -R appuser:appuser logs cache
+
+USER appuser
+
 CMD ["python", "app.py"]


### PR DESCRIPTION
## Summary
- Create dedicated `appuser` in Docker image and switch to it
- Ensure runtime directories (`logs`, `cache`) are owned by `appuser`

## Testing
- `pytest`
- `docker compose build` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bdb9e2359883328e9bac7fe2c63ce4