### PR TITLE
Stop pagination when Alibaba returns no results

### DIFF
--- a/scraper/alibaba_scraper.py
+++ b/scraper/alibaba_scraper.py
@@ -38,6 +38,9 @@ class AlibabaScraper(BaseScraper):
 
             soup = BeautifulSoup(self.driver.page_source, "html.parser")
             bloques = soup.find_all("div", class_="card-info gallery-card-layout-info")
+            if not bloques:
+                logging.info("Alibaba no devolvió más resultados; deteniendo en la página %s", pagina)
+                break
 
             for bloque in bloques:
                 try:


### PR DESCRIPTION
## Summary
- stop looping through Alibaba pages when no results are found
- log when results are exhausted

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdcf4260688332b8d7cfcb39595f60