### PR TITLE
Maneja TimeoutException al esperar contenido

### DIFF
--- a/scraper/alibaba_scraper.py
+++ b/scraper/alibaba_scraper.py
@@ -5,6 +5,7 @@ import logging
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
+from selenium.common.exceptions import TimeoutException
 from .base import BaseScraper
 
 
@@ -31,10 +32,14 @@ class AlibabaScraper(BaseScraper):
                 f"https://www.alibaba.com/trade/search?SearchText={producto.replace(' ', '+')}&page={pagina}"
             )
             self.driver.get(url)
-            WebDriverWait(self.driver, 10).until(
-                EC.presence_of_element_located((By.CSS_SELECTOR, "div.card-info.gallery-card-layout-info"))
-            )
-            self.scroll(3)
+            try:
+                WebDriverWait(self.driver, 10).until(
+                    EC.presence_of_element_located((By.CSS_SELECTOR, "div.card-info.gallery-card-layout-info"))
+                )
+                self.scroll(3)
+            except TimeoutException:
+                logging.warning("No se cargó la página %s", pagina)
+                continue
 
             soup = BeautifulSoup(self.driver.page_source, "html.parser")
             bloques = soup.find_all("div", class_="card-info gallery-card-layout-info")

--- a/scraper/aliexpress_scraper.py
+++ b/scraper/aliexpress_scraper.py
@@ -5,6 +5,7 @@ import logging
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
+from selenium.common.exceptions import TimeoutException
 from .base import BaseScraper
 
 
@@ -18,10 +19,14 @@ class AliExpressScraper(BaseScraper):
             )
             logging.info("Cargando AliExpress: Página %s", page)
             self.driver.get(url)
-            WebDriverWait(self.driver, 10).until(
-                EC.presence_of_element_located((By.CSS_SELECTOR, "div.lh_jy"))
-            )
-            self.scroll(6)
+            try:
+                WebDriverWait(self.driver, 10).until(
+                    EC.presence_of_element_located((By.CSS_SELECTOR, "div.lh_jy"))
+                )
+                self.scroll(6)
+            except TimeoutException:
+                logging.warning("No se cargó la página %s", page)
+                continue
 
             soup = BeautifulSoup(self.driver.page_source, "html.parser")
             bloques = soup.find_all("div", class_="lh_jy")

--- a/scraper/madeinchina_scraper.py
+++ b/scraper/madeinchina_scraper.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
+from selenium.common.exceptions import TimeoutException
 import logging
 from .base import BaseScraper
 
@@ -18,10 +19,14 @@ class MadeInChinaScraper(BaseScraper):
             )
             logging.info("Visitando página %s - %s", pagina, url)
             self.driver.get(url)
-            WebDriverWait(self.driver, 8).until(
-                EC.presence_of_element_located((By.CSS_SELECTOR, "div.list-node-content"))
-            )
-            self.scroll(3)
+            try:
+                WebDriverWait(self.driver, 8).until(
+                    EC.presence_of_element_located((By.CSS_SELECTOR, "div.list-node-content"))
+                )
+                self.scroll(3)
+            except TimeoutException:
+                logging.warning("No se cargó la página %s", pagina)
+                continue
 
             soup = BeautifulSoup(self.driver.page_source, "html.parser")
             bloques = soup.find_all("div", class_="list-node-content")

--- a/scraper/temu_scraper.py
+++ b/scraper/temu_scraper.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
+from selenium.common.exceptions import TimeoutException
 import logging
 from .base import BaseScraper
 
@@ -11,10 +12,15 @@ class TemuScraper(BaseScraper):
     def parse(self, producto: str):
         url = f"https://www.temu.com/pe/search.html?search_key={producto.replace(' ', '%20')}"
         self.driver.get(url)
-        WebDriverWait(self.driver, 10).until(
-            EC.presence_of_element_located((By.CSS_SELECTOR, "div._6q6qVUF5._1UrrHYym"))
-        )
-        self.scroll(5)
+        try:
+            WebDriverWait(self.driver, 10).until(
+                EC.presence_of_element_located((By.CSS_SELECTOR, "div._6q6qVUF5._1UrrHYym"))
+            )
+            self.scroll(5)
+        except TimeoutException:
+            logging.warning("No se cargó la página Temu")
+            self.close()
+            return []
 
         soup = BeautifulSoup(self.driver.page_source, "html.parser")
         productos = []


### PR DESCRIPTION
## Summary
- Wrap WebDriverWait and scrolling in try/except blocks to skip pages when content fails to load.
- Import TimeoutException in each scraper to log warnings on page load timeouts.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdcf448bcc8332be081c939672fc5a