### PR TITLE
Allow currency slash

### DIFF
--- a/scraper/alibaba_scraper.py
+++ b/scraper/alibaba_scraper.py
@@ -65,9 +65,9 @@ class AlibabaScraper(BaseScraper):
                         if precio_tag
                         else "Sin precio"
                     )
-                    moneda_match = re.search(r"[A-Z]{2,4}|\w+/", precio_texto)
+                    moneda_match = re.search(r"[A-Z]{1,4}/?|\w+/?", precio_texto)
                     moneda = (
-                        moneda_match.group(0).replace("/", "") if moneda_match else "N/A"
+                        moneda_match.group(0).rstrip() if moneda_match else "N/A"
                     )
                     precio_texto = re.sub(r"US\$|/", "", precio_texto)
                     precio_min, precio_max, precio_prom = extraer_rango_precio(precio_texto)

--- a/tests/test_currency_extraction.py
+++ b/tests/test_currency_extraction.py
@@ -3,13 +3,13 @@ from scraper.alibaba_scraper import extraer_rango_precio
 
 
 def extract_currency(precio_texto):
-    moneda_match = re.search(r"[A-Z]{2,4}|\w+/", precio_texto)
-    moneda = moneda_match.group(0).replace("/", "") if moneda_match else "N/A"
+    moneda_match = re.search(r"[A-Z]{1,4}/?|\w+/?", precio_texto)
+    moneda = moneda_match.group(0).rstrip() if moneda_match else "N/A"
     precio_texto = re.sub(r"US\$|/", "", precio_texto)
     _ = extraer_rango_precio(precio_texto)
     return moneda
 
 
 def test_currency_examples():
-    assert extract_currency("S/ 18.24 - 31.00") == "S"
+    assert extract_currency("S/ 18.24 - 31.00") == "S/"
     assert extract_currency("USD 5 - 7") == "USD"


### PR DESCRIPTION
## Summary
- expand currency regex to match 1-4 letters or words with optional slash
- keep slash when storing extracted currency
- adjust test expectations for currencies like `S/`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdda7965e0833293d866d078acc820