### PR TITLE
Handle currency and price ranges

### DIFF
--- a/tests/test_currency_extraction.py
+++ b/tests/test_currency_extraction.py
@@ -1,15 +1,20 @@
-import re
 from scraper.alibaba_scraper import extraer_rango_precio
 
 
-def extract_currency(precio_texto):
-    moneda_match = re.search(r"[A-Z]{1,4}/?|\w+/?", precio_texto)
-    moneda = moneda_match.group(0).rstrip() if moneda_match else "N/A"
-    precio_texto = re.sub(r"US\$|/", "", precio_texto)
-    _ = extraer_rango_precio(precio_texto)
-    return moneda
+def test_currency_and_range_examples():
+    minimo, maximo, _, moneda = extraer_rango_precio("S/ 18.24 - 31.00")
+    assert minimo == 18.24
+    assert maximo == 31.00
+    assert moneda == "S/"
+
+    minimo, maximo, _, moneda = extraer_rango_precio("USD 5 - 7")
+    assert minimo == 5.0
+    assert maximo == 7.0
+    assert moneda == "USD"
 
 
-def test_currency_examples():
-    assert extract_currency("S/ 18.24 - 31.00") == "S/"
-    assert extract_currency("USD 5 - 7") == "USD"
+def test_range_detection_specific():
+    minimo, maximo, _, moneda = extraer_rango_precio("USD 72.41-80.00")
+    assert minimo == 72.41
+    assert maximo == 80.00
+    assert moneda == "USD"


### PR DESCRIPTION
## Summary
- extract currency before stripping non numeric characters and detect price ranges
- include currency in price parsing and scraper results
- add tests for currency and range detection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bddff1683883329eb4cbcdfca615fc