### PR TITLE
Use module-level logger across modules

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,6 +8,8 @@ from config import Config
 from tasks import scrapear
 import logging_config
 
+logger = logging.getLogger(__name__)
+
 app = Flask(__name__)
 app.config.from_object(Config)
 CORS(app, origins=app.config["ALLOWED_ORIGINS"])  # Permitir peticiones desde dominios permitidos
@@ -19,7 +21,7 @@ def scrape():
     plataforma = data.get("plataforma")
 
     if not producto or not plataforma:
-        logging.warning("Parametros faltantes en solicitud de scraping")
+        logger.warning("Parametros faltantes en solicitud de scraping")
         return (
             jsonify(
                 {
@@ -29,11 +31,11 @@ def scrape():
             ),
             400,
         )
-    logging.info("Iniciando scraping de %s en %s", producto, plataforma)
+    logger.info("Iniciando scraping de %s en %s", producto, plataforma)
     try:
         task = scrapear.delay(producto, plataforma)
     except OperationalError:
-        logging.exception("Error al enviar la tarea de scraping")
+        logger.exception("Error al enviar la tarea de scraping")
         return (
             jsonify(
                 {

--- a/scraper/alibaba_scraper.py
+++ b/scraper/alibaba_scraper.py
@@ -8,6 +8,8 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import TimeoutException
 from .base import BaseScraper
 
+logger = logging.getLogger(__name__)
+
 
 def extraer_rango_precio(texto):
     match = re.findall(r"([\d.,]+)", texto)
@@ -27,7 +29,7 @@ class AlibabaScraper(BaseScraper):
         resultados = []
 
         for pagina in range(1, max_paginas + 1):
-            logging.info("Scrapeando página %s", pagina)
+            logger.info("Scrapeando página %s", pagina)
             url = (
                 f"https://www.alibaba.com/trade/search?SearchText={producto.replace(' ', '+')}&page={pagina}"
             )
@@ -38,13 +40,13 @@ class AlibabaScraper(BaseScraper):
                 )
                 self.scroll(3)
             except TimeoutException:
-                logging.warning("No se cargó la página %s", pagina)
+                logger.warning("No se cargó la página %s", pagina)
                 continue
 
             soup = BeautifulSoup(self.driver.page_source, "html.parser")
             bloques = soup.find_all("div", class_="card-info gallery-card-layout-info")
             if not bloques:
-                logging.info("Alibaba no devolvió más resultados; deteniendo en la página %s", pagina)
+                logger.info("Alibaba no devolvió más resultados; deteniendo en la página %s", pagina)
                 break
 
             for bloque in bloques:
@@ -106,7 +108,7 @@ class AlibabaScraper(BaseScraper):
                         }
                     )
                 except Exception as e:
-                    logging.error("Error en producto: %s", e)
+                    logger.error("Error en producto: %s", e)
                     continue
 
         self.close()

--- a/scraper/aliexpress_scraper.py
+++ b/scraper/aliexpress_scraper.py
@@ -8,6 +8,8 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import TimeoutException
 from .base import BaseScraper
 
+logger = logging.getLogger(__name__)
+
 
 class AliExpressScraper(BaseScraper):
     def parse(self, producto: str, paginas: int = 4):
@@ -17,7 +19,7 @@ class AliExpressScraper(BaseScraper):
             url = (
                 f"https://es.aliexpress.com/wholesale?SearchText={producto.replace(' ', '+')}&page={page}"
             )
-            logging.info("Cargando AliExpress: Página %s", page)
+            logger.info("Cargando AliExpress: Página %s", page)
             self.driver.get(url)
             try:
                 WebDriverWait(self.driver, 10).until(
@@ -25,12 +27,12 @@ class AliExpressScraper(BaseScraper):
                 )
                 self.scroll(6)
             except TimeoutException:
-                logging.warning("No se cargó la página %s", page)
+                logger.warning("No se cargó la página %s", page)
                 continue
 
             soup = BeautifulSoup(self.driver.page_source, "html.parser")
             bloques = soup.find_all("div", class_="lh_jy")
-            logging.info("Página %s: %s productos encontrados", page, len(bloques))
+            logger.info("Página %s: %s productos encontrados", page, len(bloques))
 
             for bloque in bloques:
                 try:
@@ -96,7 +98,7 @@ class AliExpressScraper(BaseScraper):
                         }
                     )
                 except Exception as e:
-                    logging.error("Error en producto: %s", e)
+                    logger.error("Error en producto: %s", e)
                     continue
 
         self.close()

--- a/scraper/madeinchina_scraper.py
+++ b/scraper/madeinchina_scraper.py
@@ -7,6 +7,8 @@ from selenium.common.exceptions import TimeoutException
 import logging
 from .base import BaseScraper
 
+logger = logging.getLogger(__name__)
+
 
 class MadeInChinaScraper(BaseScraper):
     def parse(self, producto: str, paginas: int = 4):
@@ -17,7 +19,7 @@ class MadeInChinaScraper(BaseScraper):
                 "https://es.made-in-china.com/productSearch?keyword="
                 f"{producto.replace(' ', '+')}&currentPage={pagina}&type=Product"
             )
-            logging.info("Visitando página %s - %s", pagina, url)
+            logger.info("Visitando página %s - %s", pagina, url)
             self.driver.get(url)
             try:
                 WebDriverWait(self.driver, 8).until(
@@ -25,12 +27,12 @@ class MadeInChinaScraper(BaseScraper):
                 )
                 self.scroll(3)
             except TimeoutException:
-                logging.warning("No se cargó la página %s", pagina)
+                logger.warning("No se cargó la página %s", pagina)
                 continue
 
             soup = BeautifulSoup(self.driver.page_source, "html.parser")
             bloques = soup.find_all("div", class_="list-node-content")
-            logging.info("Página %s: %s productos encontrados", pagina, len(bloques))
+            logger.info("Página %s: %s productos encontrados", pagina, len(bloques))
 
             for bloque in bloques:
                 try:
@@ -88,7 +90,7 @@ class MadeInChinaScraper(BaseScraper):
                         }
                     )
                 except Exception as e:
-                    logging.error("Error procesando producto en página %s: %s", pagina, e)
+                    logger.error("Error procesando producto en página %s: %s", pagina, e)
                     continue
 
         self.close()

--- a/scraper/temu_scraper.py
+++ b/scraper/temu_scraper.py
@@ -7,6 +7,8 @@ from selenium.common.exceptions import TimeoutException
 import logging
 from .base import BaseScraper
 
+logger = logging.getLogger(__name__)
+
 
 class TemuScraper(BaseScraper):
     def parse(self, producto: str):
@@ -18,7 +20,7 @@ class TemuScraper(BaseScraper):
             )
             self.scroll(5)
         except TimeoutException:
-            logging.warning("No se cargó la página Temu")
+            logger.warning("No se cargó la página Temu")
             self.close()
             return []
 
@@ -26,7 +28,7 @@ class TemuScraper(BaseScraper):
         productos = []
 
         bloques = soup.find_all("div", class_="_6q6qVUF5 _1UrrHYym")
-        logging.info("Se encontraron %s productos en Temu", len(bloques))
+        logger.info("Se encontraron %s productos en Temu", len(bloques))
 
         for bloque in bloques:
             try:
@@ -72,7 +74,7 @@ class TemuScraper(BaseScraper):
                     }
                 )
             except Exception as e:
-                logging.error("Error procesando producto: %s", e)
+                logger.error("Error procesando producto: %s", e)
                 continue
 
         self.close()

--- a/tasks.py
+++ b/tasks.py
@@ -5,6 +5,8 @@ from flask import Flask
 import logging
 import logging_config
 
+logger = logging.getLogger(__name__)
+
 from config import Config
 from scraper.aliexpress_scraper import AliExpressScraper
 from scraper.temu_scraper import TemuScraper
@@ -32,16 +34,16 @@ SCRAPERS = {
 def scrapear(producto: str, plataforma: str):
     scraper_info = SCRAPERS.get(plataforma)
     if scraper_info is None:
-        logging.error("Plataforma no soportada: %s", plataforma)
+        logger.error("Plataforma no soportada: %s", plataforma)
         return {"success": False, "message": "Plataforma no soportada."}
 
     scraper_cls, csv_name = scraper_info
-    logging.info("Ejecutando scraper %s para %s", plataforma, producto)
+    logger.info("Ejecutando scraper %s para %s", plataforma, producto)
     scraper = scraper_cls()
     try:
         productos = scraper.parse(producto)
     except Exception as e:
-        logging.exception("Error al ejecutar scraper")
+        logger.exception("Error al ejecutar scraper")
         return {"success": False, "message": str(e)}
     archivo_csv = os.path.join("data", csv_name)
 
@@ -49,8 +51,8 @@ def scrapear(producto: str, plataforma: str):
         os.makedirs("data", exist_ok=True)
         df = pd.DataFrame(productos)
         df.to_csv(archivo_csv, index=False, encoding="utf-8-sig")
-        logging.info("Scraping completado: %d productos", len(productos))
+        logger.info("Scraping completado: %d productos", len(productos))
         return {"success": True, "productos": productos, "archivo": csv_name}
 
-    logging.warning("No se encontraron productos para %s en %s", producto, plataforma)
+    logger.warning("No se encontraron productos para %s en %s", producto, plataforma)
     return {"success": False, "message": "No se encontraron productos."}


### PR DESCRIPTION
## Summary
- declare `logger = logging.getLogger(__name__)` in app, tasks, and scraper modules
- replace direct `logging.info/warning/error` calls with the module logger

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bddff977fc8332a0ce66a225e0c90d