### PR TITLE
feat(aliexpress): cache HTML on timeout

### DIFF
--- a/scraper/aliexpress_scraper.py
+++ b/scraper/aliexpress_scraper.py
@@ -2,6 +2,7 @@ from bs4 import BeautifulSoup
 from datetime import datetime
 import re
 import logging
+import os
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
@@ -25,7 +26,13 @@ class AliExpressScraper(BaseScraper):
                 )
                 self.scroll(6)
             except TimeoutException:
-                logging.warning("No se cargó la página %s", page)
+                os.makedirs("cache", exist_ok=True)
+                file_path = f"cache/aliexpress_p{page}.html"
+                with open(file_path, "w", encoding="utf-8") as f:
+                    f.write(self.driver.page_source)
+                logging.warning(
+                    "No se cargó la página %s. HTML guardado en %s", page, file_path
+                )
                 continue
 
             soup = BeautifulSoup(self.driver.page_source, "html.parser")


### PR DESCRIPTION
## Summary
- cache AliExpress HTML when page load times out
- log where the HTML was saved for easier debugging

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bddffed89c8332a7809d1d16d11daf