### PR TITLE
Remove unused ChromeDriverManager dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,5 @@ flask
 selenium
 beautifulsoup4
 pandas
-webdriver-manager
 celery[redis]==5.3.4  # pinned for Python 3.10–3.12 compatibility
 flask-cors

--- a/scraper/base.py
+++ b/scraper/base.py
@@ -1,7 +1,6 @@
 import os
 from selenium import webdriver
 from selenium.webdriver.chrome.service import Service
-from webdriver_manager.chrome import ChromeDriverManager
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 

--- a/tests/test_base_scraper.py
+++ b/tests/test_base_scraper.py
@@ -6,13 +6,15 @@ from scraper.base import BaseScraper
 
 class TestBaseScraper(unittest.TestCase):
     @patch("scraper.base.webdriver.Chrome")
-    @patch("scraper.base.ChromeDriverManager")
-    def test_initialization_and_close(self, mock_manager, mock_chrome):
+    @patch("scraper.base.Service")
+    def test_initialization_and_close(self, mock_service, mock_chrome):
         mock_driver = MagicMock()
         mock_chrome.return_value = mock_driver
-        mock_manager.return_value.install.return_value = "/path/to/chromedriver"
 
         scraper = BaseScraper()
+
+        mock_service.assert_called_once_with("/usr/bin/chromedriver")
+        mock_chrome.assert_called_once()
         self.assertIs(scraper.driver, mock_driver)
 
         scraper.close()


### PR DESCRIPTION
## Summary
- drop unused ChromeDriverManager import and use fixed chromedriver path
- update BaseScraper test to mock Service instead of ChromeDriverManager
- remove webdriver-manager from requirements

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bde3d57d448332b7f6db6d03601c43