### PR TITLE
Sanitize download path and add traversal tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,8 +1,9 @@
-from flask import Flask, request, jsonify, send_file
+from flask import Flask, request, jsonify, send_from_directory
 from flask_cors import CORS
 import logging
 import os
 from kombu.exceptions import OperationalError
+from werkzeug.exceptions import NotFound
 
 from config import Config
 from tasks import scrapear
@@ -60,13 +61,14 @@ def resultado(task_id):
 
 @app.route("/api/descargar/<nombre>")
 def descargar(nombre):
-    path = f"data/{nombre}"
-    if not os.path.exists(path):
+    safe_name = os.path.basename(nombre)
+    try:
+        return send_from_directory("data", safe_name, as_attachment=True)
+    except NotFound:
         return (
             jsonify({"success": False, "message": "Archivo no encontrado"}),
             404,
         )
-    return send_file(path, as_attachment=True)
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0", debug=app.config["DEBUG"])

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -52,3 +52,13 @@ def test_scrape_endpoint_missing_params(client):
     data = response.get_json()
     assert data["success"] is False
     assert "message" in data
+
+
+def test_descargar_rejects_traversal_outside_data(client):
+    response = client.get("/api/descargar/..%2Fapp.py")
+    assert response.status_code == 404
+
+
+def test_descargar_rejects_parent_directory_reference(client):
+    response = client.get("/api/descargar/..")
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary
- Sanitize download requests with `os.path.basename` and serve files via `send_from_directory`.
- Add regression tests verifying `../` path traversal attempts are rejected.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bde95ccc20833295712b00acd465cc