### PR TITLE
Handle missing Chromium executables

### DIFF
--- a/scraper/base.py
+++ b/scraper/base.py
@@ -11,7 +11,13 @@ class BaseScraper:
 
     def __init__(self, data_dir: str = "data"):
         options = webdriver.ChromeOptions()
-        options.binary_location = "/usr/bin/chromium"
+
+        chromium_path = shutil.which("chromium")
+        if not chromium_path:
+            raise FileNotFoundError(
+                "Chromium executable not found. Please install chromium or adjust your PATH."
+            )
+        options.binary_location = chromium_path
         ##options.add_argument("--headless=new")
         options.add_argument("--no-sandbox")
         options.add_argument("--disable-dev-shm-usage")
@@ -20,7 +26,12 @@ class BaseScraper:
         options.add_argument(f"--user-data-dir={profile_dir}")
         options.add_argument("--start-maximized")
 
-        service = Service("/usr/bin/chromedriver")
+        chromedriver_path = shutil.which("chromedriver")
+        if not chromedriver_path:
+            raise FileNotFoundError(
+                "Chromedriver executable not found. Please install chromedriver or adjust your PATH."
+            )
+        service = Service(chromedriver_path)
         self.driver = webdriver.Chrome(service=service, options=options)
 
         self.data_dir = data_dir

--- a/tests/test_base_scraper.py
+++ b/tests/test_base_scraper.py
@@ -7,12 +7,16 @@ from scraper.base import BaseScraper
 class TestBaseScraper(unittest.TestCase):
     @patch("scraper.base.webdriver.Chrome")
     @patch("scraper.base.Service")
-    def test_initialization_and_close(self, mock_service, mock_chrome):
+    @patch("scraper.base.shutil.which")
+    def test_initialization_and_close(self, mock_which, mock_service, mock_chrome):
+        mock_which.side_effect = lambda name: f"/usr/bin/{name}"
         mock_driver = MagicMock()
         mock_chrome.return_value = mock_driver
 
         scraper = BaseScraper()
 
+        mock_which.assert_any_call("chromium")
+        mock_which.assert_any_call("chromedriver")
         mock_service.assert_called_once_with("/usr/bin/chromedriver")
         mock_chrome.assert_called_once()
         self.assertIs(scraper.driver, mock_driver)
@@ -21,6 +25,23 @@ class TestBaseScraper(unittest.TestCase):
         mock_driver.quit.assert_called_once()
         self.assertIsNone(scraper.driver)
 
+    @patch("scraper.base.shutil.which")
+    def test_missing_chromium_raises_error(self, mock_which):
+        mock_which.side_effect = (
+            lambda name: "/usr/bin/chromedriver" if name == "chromedriver" else None
+        )
+        with self.assertRaises(FileNotFoundError):
+            BaseScraper()
+
+    @patch("scraper.base.shutil.which")
+    def test_missing_chromedriver_raises_error(self, mock_which):
+        mock_which.side_effect = (
+            lambda name: "/usr/bin/chromium" if name == "chromium" else None
+        )
+        with self.assertRaises(FileNotFoundError):
+            BaseScraper()
+
 
 if __name__ == "__main__":
     unittest.main()
+


### PR DESCRIPTION
## Summary
- Locate `chromium` and `chromedriver` using `shutil.which` in `BaseScraper`
- Raise explicit errors when required browser binaries are absent
- Extend tests to cover binary lookup and error handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bde95d99b4833282446387e57a3a14