### PR TITLE
Fix price parsing in AliExpress scraper and add regression test

### DIFF
--- a/scraper/aliexpress_scraper.py
+++ b/scraper/aliexpress_scraper.py
@@ -9,6 +9,19 @@ from selenium.common.exceptions import TimeoutException
 from .base import BaseScraper
 
 
+def limpiar_precio(texto: str):
+    """Convierte una cadena de precio a ``float``.
+
+    Primero elimina los separadores de miles (``.``) y luego
+    reemplaza la coma decimal por un punto. Si el resultado queda
+    vacío, retorna ``None`` en lugar de intentar la conversión.
+    """
+
+    numero = re.sub(r"[^0-9.,]", "", texto or "")
+    numero = numero.replace(".", "").replace(",", ".").strip()
+    return float(numero) if numero else None
+
+
 class AliExpressScraper(BaseScraper):
     def parse(self, producto: str, paginas: int = 4):
         try:
@@ -46,18 +59,14 @@ class AliExpressScraper(BaseScraper):
                         precio_tag = card.select_one("[data-price]")
                         if precio_tag:
                             precio_texto = precio_tag.get("data-price") or precio_tag.text
-                            precio_texto = (
-                                re.sub(r"[^0-9.,]", "", precio_texto).replace(",", ".")
-                            )
-                            precio = float(precio_texto) if precio_texto else None
+                            precio = limpiar_precio(precio_texto)
                         else:
                             precio = None
 
                         precio_ori_tag = card.select_one("[data-original-price]")
                         if precio_ori_tag:
                             texto = precio_ori_tag.get("data-original-price") or precio_ori_tag.text
-                            texto = re.sub(r"[^0-9.,]", "", texto).replace(",", ".")
-                            precio_original = float(texto) if texto else None
+                            precio_original = limpiar_precio(texto)
                         else:
                             precio_original = None
 

--- a/tests/test_aliexpress_price.py
+++ b/tests/test_aliexpress_price.py
@@ -1,0 +1,5 @@
+from scraper.aliexpress_scraper import limpiar_precio
+
+
+def test_limpiar_precio_con_separador_miles():
+    assert limpiar_precio("1.299,00") == 1299.00


### PR DESCRIPTION
## Summary
- ensure AliExpress price parsing removes thousand separators and handles empty strings
- cover price parsing with a regression test for "1.299,00"

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bded229d9083328d4d3e36b57c2708