### PR TITLE
Encode AliExpress search terms with quote_plus

### DIFF
--- a/scraper/aliexpress_scraper.py
+++ b/scraper/aliexpress_scraper.py
@@ -2,6 +2,7 @@ from bs4 import BeautifulSoup
 from datetime import datetime
 import re
 import logging
+from urllib.parse import quote_plus
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
@@ -16,7 +17,7 @@ class AliExpressScraper(BaseScraper):
 
             for page in range(1, paginas + 1):
                 url = (
-                    f"https://es.aliexpress.com/wholesale?SearchText={producto.replace(' ', '+')}&page={page}"
+                    f"https://es.aliexpress.com/wholesale?SearchText={quote_plus(producto)}&page={page}"
                 )
                 logging.info("Cargando AliExpress: Página %s", page)
                 self.driver.get(url)

--- a/tests/test_aliexpress_scraper.py
+++ b/tests/test_aliexpress_scraper.py
@@ -1,0 +1,32 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from urllib.parse import quote_plus
+
+from selenium.common.exceptions import TimeoutException
+
+from scraper.aliexpress_scraper import AliExpressScraper
+
+
+class TestAliExpressScraper(unittest.TestCase):
+    @patch("scraper.aliexpress_scraper.BaseScraper.__init__", return_value=None)
+    @patch("scraper.aliexpress_scraper.WebDriverWait")
+    def test_url_encoding_special_characters(self, mock_wait, mock_base_init):
+        mock_wait.return_value.until.side_effect = TimeoutException
+
+        scraper = AliExpressScraper()
+        mock_driver = MagicMock()
+        scraper.driver = mock_driver
+
+        producto = "zapatos niño & niña"
+        scraper.parse(producto, paginas=1)
+
+        encoded = quote_plus(producto)
+        expected_url = (
+            f"https://es.aliexpress.com/wholesale?SearchText={encoded}&page=1"
+        )
+        mock_driver.get.assert_called_once_with(expected_url)
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- Use `urllib.parse.quote_plus` to encode AliExpress search queries
- Add unit test ensuring special characters like `zapatos niño & niña` are encoded in URL

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bded2523ec8332b60d9a0799078439