### PR TITLE
Handle missing discount text and add Temu test

### DIFF
--- a/scraper/aliexpress_scraper.py
+++ b/scraper/aliexpress_scraper.py
@@ -37,7 +37,8 @@ class AliExpressScraper(BaseScraper):
                 cargada = False
                 for intento in range(3):
                     try:
-                        self.driver.get(url)
+                        if intento == 0:
+                            self.driver.get(url)
                         WebDriverWait(self.driver, 10).until(
                             EC.presence_of_element_located(
                                 (By.CSS_SELECTOR, "div.search-item-card-wrapper-gallery")
@@ -86,13 +87,15 @@ class AliExpressScraper(BaseScraper):
                             precio_original = None
 
                         descuento_tag = card.select_one("[data-discount]")
-                        descuento = (
-                            descuento_tag.get("data-discount")
-                            if descuento_tag and descuento_tag.get("data-discount")
-                            else descuento_tag.text.strip()
-                            if descuento_tag
-                            else None
-                        )
+                        if descuento_tag:
+                            if descuento_tag.get("data-discount"):
+                                descuento = descuento_tag.get("data-discount")
+                            elif descuento_tag.text:
+                                descuento = descuento_tag.text.strip()
+                            else:
+                                descuento = None
+                        else:
+                            descuento = None
 
                         ventas_tag = card.select_one("[data-sold]")
                         if ventas_tag:

--- a/scraper/temu_scraper.py
+++ b/scraper/temu_scraper.py
@@ -57,7 +57,11 @@ class TemuScraper(BaseScraper):
                         precio_original = None
 
                     descuento_tag = bloque.find("div", class_="_1LLbpUTn")
-                    descuento_extra = descuento_tag.text.strip() if descuento_tag else None
+                    descuento_extra = (
+                        descuento_tag.text.strip()
+                        if descuento_tag and descuento_tag.text
+                        else None
+                    )
 
                     ventas_tag = bloque.find("span", class_="_3vfo0XTx")
                     ventas = ventas_tag.text.strip() if ventas_tag else "0"

--- a/tests/test_temu_scraper.py
+++ b/tests/test_temu_scraper.py
@@ -1,0 +1,36 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from scraper.temu_scraper import TemuScraper
+
+
+class TestTemuScraper(unittest.TestCase):
+    @patch("scraper.temu_scraper.BaseScraper.__init__", return_value=None)
+    @patch("scraper.temu_scraper.WebDriverWait")
+    def test_parse_product_without_discount(self, mock_wait, mock_base_init):
+        mock_wait.return_value.until.return_value = True
+
+        scraper = TemuScraper()
+        mock_driver = MagicMock()
+        scraper.driver = mock_driver
+        scraper.scroll = MagicMock()
+
+        mock_driver.page_source = """
+        <html><body>
+        <div class="_6q6qVUF5 _1UrrHYym">
+            <h2 class="_2BvQbnbN">Producto</h2>
+            <span class="_2de9ERAH">10</span>
+            <span class="_3SrxhhHh">99</span>
+            <span class="_3vfo0XTx">1 vendido</span>
+            <a href="/pe/item"></a>
+        </div>
+        </body></html>
+        """
+
+        productos = scraper.parse("producto")
+
+        self.assertIsNone(productos[0]["descuento_extra"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Guard against missing discount text in Temu scraper
- Refactor AliExpress discount extraction for clarity and retry stability
- Add unit test covering Temu product without discount

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bdef106fac83329ce70ac8a476c13e