### PR TITLE
Encode AliExpress search queries before navigation

### DIFF
--- a/scraper/aliexpress_scraper.py
+++ b/scraper/aliexpress_scraper.py
@@ -214,7 +214,7 @@ class AliExpressScraper(BaseScraper):
             resultados: List[Dict] = []
 
             for page in range(1, paginas + 1):
-                q = producto.replace(" ", "+")
+                q = quote_plus(producto)
                 url = f"https://es.aliexpress.com/wholesale?SearchText={q}&page={page}"
                 logging.info("Cargando AliExpress: Página %s -> %s", page, url)
                 self.driver.get(url)
@@ -268,7 +268,10 @@ class AliExpressScraper(BaseScraper):
 
                 # Fallback BeautifulSoup si quedó vacío
                 if count_page == 0:
-                    soup = BeautifulSoup(self.driver.page_source, "html.parser")
+                    page_source = getattr(self.driver, "page_source", "") or ""
+                    if not isinstance(page_source, (str, bytes)):
+                        page_source = str(page_source)
+                    soup = BeautifulSoup(page_source, "html.parser")
                     for sel in containers:
                         bs_cards = soup.select(sel)
                         if not bs_cards:


### PR DESCRIPTION
## Summary
- ensure AliExpress search URLs escape special characters with quote_plus
- guard the BeautifulSoup fallback against non-string page sources returned by mocked drivers

## Testing
- pytest tests/test_aliexpress_scraper.py

------
https://chatgpt.com/codex/tasks/task_e_68d963d9382c8332a8798e9efa465051