### PR TITLE
Use quote_plus for Alibaba search URLs

### DIFF
--- a/scraper/alibaba_scraper.py
+++ b/scraper/alibaba_scraper.py
@@ -1,7 +1,9 @@
-from bs4 import BeautifulSoup
-from datetime import datetime
 import re
 import logging
+from datetime import datetime
+from urllib.parse import quote_plus
+
+from bs4 import BeautifulSoup
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
@@ -45,8 +47,9 @@ class AlibabaScraper(BaseScraper):
 
             for pagina in range(1, max_paginas + 1):
                 logging.info("Scrapeando página %s", pagina)
+                encoded = quote_plus(producto)
                 url = (
-                    f"https://www.alibaba.com/trade/search?SearchText={producto.replace(' ', '+')}&page={pagina}"
+                    f"https://www.alibaba.com/trade/search?SearchText={encoded}&page={pagina}"
                 )
 
                 cargada = False

--- a/tests/test_alibaba_scraper.py
+++ b/tests/test_alibaba_scraper.py
@@ -1,0 +1,32 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from urllib.parse import quote_plus
+
+from scraper.alibaba_scraper import AlibabaScraper
+
+
+class TestAlibabaScraper(unittest.TestCase):
+    @patch("scraper.alibaba_scraper.BaseScraper.__init__", return_value=None)
+    @patch("scraper.alibaba_scraper.WebDriverWait")
+    def test_url_encoding_special_characters(self, mock_wait, mock_base_init):
+        mock_wait.return_value.until.return_value = True
+
+        scraper = AlibabaScraper()
+        mock_driver = MagicMock()
+        mock_driver.page_source = "<html></html>"
+        scraper.driver = mock_driver
+        scraper.scroll = MagicMock()
+
+        producto = "zapatos niño & niña"
+        scraper.parse(producto, max_paginas=1)
+
+        encoded = quote_plus(producto)
+        expected_url = (
+            f"https://www.alibaba.com/trade/search?SearchText={encoded}&page=1"
+        )
+        mock_driver.get.assert_called_with(expected_url)
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- encode Alibaba search text with `urllib.parse.quote_plus` when building the results URL
- add a unit test ensuring the Alibaba scraper requests encoded URLs for queries with special characters

## Testing
- pytest tests/test_alibaba_scraper.py

------
https://chatgpt.com/codex/tasks/task_e_68d96ea6ff4c833297c873b4cd41ec1c