### PR TITLE
Encode Temu search URL correctly

### DIFF
--- a/scraper/temu_scraper.py
+++ b/scraper/temu_scraper.py
@@ -4,6 +4,7 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import WebDriverException
+from urllib.parse import quote_plus
 import logging
 from .base import BaseScraper
 
@@ -11,7 +12,8 @@ from .base import BaseScraper
 class TemuScraper(BaseScraper):
     def parse(self, producto: str):
         try:
-            url = f"https://www.temu.com/pe/search.html?search_key={producto.replace(' ', '%20')}"
+            encoded_product = quote_plus(producto)
+            url = f"https://www.temu.com/pe/search.html?search_key={encoded_product}"
             productos = []
 
             cargada = False

--- a/tests/test_temu_scraper.py
+++ b/tests/test_temu_scraper.py
@@ -1,5 +1,6 @@
 import unittest
 from unittest.mock import MagicMock, patch
+from urllib.parse import quote_plus
 
 from scraper.temu_scraper import TemuScraper
 
@@ -14,6 +15,7 @@ class TestTemuScraper(unittest.TestCase):
         mock_driver = MagicMock()
         scraper.driver = mock_driver
         scraper.scroll = MagicMock()
+        scraper.close = MagicMock()
 
         mock_driver.page_source = """
         <html><body>
@@ -27,9 +29,15 @@ class TestTemuScraper(unittest.TestCase):
         </body></html>
         """
 
-        productos = scraper.parse("producto")
+        search_term = "cafetera & taza fría"
+        productos = scraper.parse(search_term)
 
         self.assertIsNone(productos[0]["descuento_extra"])
+        expected_url = (
+            "https://www.temu.com/pe/search.html?search_key="
+            f"{quote_plus(search_term)}"
+        )
+        mock_driver.get.assert_called_once_with(expected_url)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- ensure the Temu scraper encodes search terms with urllib.parse.quote_plus when building the search URL
- extend the Temu scraper test to verify driver.get receives the encoded URL for terms with spaces, accents, and symbols

## Testing
- pytest tests/test_temu_scraper.py

------
https://chatgpt.com/codex/tasks/task_e_68d96ea5ca5c8332a05fc0beb8e9e87e