### PR TITLE
Fix MadeInChina scraper encoding and add unit test

### DIFF
--- a/scraper/madeinchina_scraper.py
+++ b/scraper/madeinchina_scraper.py
@@ -5,6 +5,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import WebDriverException
 import logging
+from urllib.parse import quote_plus
 from .base import BaseScraper
 
 
@@ -16,7 +17,7 @@ class MadeInChinaScraper(BaseScraper):
             for pagina in range(1, paginas + 1):
                 url = (
                     "https://es.made-in-china.com/productSearch?keyword="
-                    f"{producto.replace(' ', '+')}&currentPage={pagina}&type=Product"
+                    f"{quote_plus(producto)}&currentPage={pagina}&type=Product"
                 )
                 logging.info("Visitando página %s - %s", pagina, url)
 
@@ -77,7 +78,7 @@ class MadeInChinaScraper(BaseScraper):
                         moq_tag = bloque.find("div", class_="info")
                         moq = moq_tag.text.strip() if moq_tag else "No info"
 
-                        empresa_tag = bloque.find("a", class_="compnay-name")
+                        empresa_tag = bloque.find("a", class_="company-name")
                         empresa = (
                             empresa_tag.text.strip() if empresa_tag else "Desconocida"
                         )

--- a/tests/test_madeinchina_scraper.py
+++ b/tests/test_madeinchina_scraper.py
@@ -1,0 +1,35 @@
+from unittest.mock import MagicMock, patch
+
+from scraper.madeinchina_scraper import MadeInChinaScraper
+
+
+@patch("scraper.madeinchina_scraper.BaseScraper.__init__", return_value=None)
+@patch("scraper.madeinchina_scraper.WebDriverWait")
+def test_parse_returns_company_name(mock_wait, mock_base_init):
+    mock_wait.return_value.until.return_value = True
+
+    scraper = MadeInChinaScraper()
+    scraper.driver = MagicMock()
+    scraper.scroll = MagicMock()
+    scraper.close = MagicMock()
+
+    scraper.driver.get.return_value = None
+    scraper.driver.page_source = """
+    <html><body>
+        <div class=\"list-node-content\">
+            <h2 class=\"product-name\" title=\"Producto\">
+                <a href=\"/product\">Producto</a>
+            </h2>
+            <strong class=\"price\">US$1-2</strong>
+            <div class=\"info\">MOQ info</div>
+            <a class=\"company-name\">Empresa S.A.</a>
+            <div class=\"company-address-detail\">Perú</div>
+        </div>
+    </body></html>
+    """
+
+    resultados = scraper.parse("producto de prueba", paginas=1)
+
+    assert resultados
+    assert resultados[0]["empresa"] == "Empresa S.A."
+    scraper.close.assert_called_once()


### PR DESCRIPTION
## Summary
- encode the search keyword for Made-in-China requests using quote_plus
- correct the company name selector to match the expected HTML class
- add a unit test ensuring the scraper captures the company name from results

## Testing
- pytest tests/test_madeinchina_scraper.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d96ea7f3f48332a95f2a063365437b