### PR TITLE
Sanitize Temu price parsing and add coverage for currency symbols

### DIFF
--- a/scraper/temu_scraper.py
+++ b/scraper/temu_scraper.py
@@ -6,10 +6,37 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import WebDriverException
 from urllib.parse import quote_plus
 import logging
+import re
 from .base import BaseScraper
 
 
 class TemuScraper(BaseScraper):
+    @staticmethod
+    def _sanitize_numeric_text(text: str) -> str:
+        if not text:
+            return ""
+        return re.sub(r"[^\d,]", "", text)
+
+    @classmethod
+    def _float_from_text(cls, text: str):
+        sanitized = cls._sanitize_numeric_text(text)
+        if not sanitized:
+            return None
+        if "," in sanitized:
+            parts = sanitized.split(",")
+            last_group = parts[-1]
+            if len(last_group) in (1, 2):
+                integer_part = "".join(parts[:-1]) or "0"
+                normalized = f"{integer_part}.{last_group}"
+            else:
+                normalized = sanitized.replace(",", "")
+        else:
+            normalized = sanitized
+        try:
+            return float(normalized)
+        except ValueError:
+            return None
+
     def parse(self, producto: str):
         try:
             encoded_product = quote_plus(producto)
@@ -45,18 +72,28 @@ class TemuScraper(BaseScraper):
                     titulo_tag = bloque.find("h2", class_="_2BvQbnbN")
                     titulo = titulo_tag.text.strip() if titulo_tag else "Sin título"
 
-                    precio_entero = bloque.find("span", class_="_2de9ERAH")
-                    precio_decimal = bloque.find("span", class_="_3SrxhhHh")
-                    if precio_entero and precio_decimal:
-                        precio = float(f"{precio_entero.text}.{precio_decimal.text}")
-                    else:
-                        precio = None
+                    precio_entero_tag = bloque.find("span", class_="_2de9ERAH")
+                    precio_decimal_tag = bloque.find("span", class_="_3SrxhhHh")
+
+                    entero_limpio = self._sanitize_numeric_text(
+                        precio_entero_tag.text if precio_entero_tag else ""
+                    ).replace(",", "")
+                    decimal_limpio = self._sanitize_numeric_text(
+                        precio_decimal_tag.text if precio_decimal_tag else ""
+                    ).replace(",", "")
+
+                    precio_texto = entero_limpio
+                    if decimal_limpio:
+                        precio_texto = (
+                            f"{precio_texto},{decimal_limpio}" if precio_texto else f"0,{decimal_limpio}"
+                        )
+
+                    precio = self._float_from_text(precio_texto)
 
                     precio_ori_tag = bloque.find("span", class_="_3TAPHDOX")
-                    if precio_ori_tag:
-                        precio_original = float(precio_ori_tag.text.strip())
-                    else:
-                        precio_original = None
+                    precio_original = self._float_from_text(
+                        precio_ori_tag.text.strip() if precio_ori_tag else ""
+                    )
 
                     descuento_tag = bloque.find("div", class_="_1LLbpUTn")
                     descuento_extra = (

--- a/tests/test_temu_scraper.py
+++ b/tests/test_temu_scraper.py
@@ -39,6 +39,38 @@ class TestTemuScraper(unittest.TestCase):
         )
         mock_driver.get.assert_called_once_with(expected_url)
 
+    @patch("scraper.temu_scraper.BaseScraper.__init__", return_value=None)
+    @patch("scraper.temu_scraper.WebDriverWait")
+    def test_parse_price_with_currency_and_thousands(self, mock_wait, mock_base_init):
+        mock_wait.return_value.until.return_value = True
+
+        scraper = TemuScraper()
+        mock_driver = MagicMock()
+        scraper.driver = mock_driver
+        scraper.scroll = MagicMock()
+        scraper.close = MagicMock()
+
+        mock_driver.page_source = """
+        <html><body>
+        <div class="_6q6qVUF5 _1UrrHYym">
+            <h2 class="_2BvQbnbN">Producto Premium</h2>
+            <span class="_2de9ERAH">S/ 1,299</span>
+            <span class="_3SrxhhHh">50</span>
+            <span class="_3TAPHDOX">US$ 1,499</span>
+            <a href="/pe/item-premium"></a>
+        </div>
+        </body></html>
+        """
+
+        productos = scraper.parse("producto premium")
+
+        self.assertEqual(len(productos), 1)
+        producto = productos[0]
+        self.assertEqual(producto["titulo"], "Producto Premium")
+        self.assertEqual(producto["precio"], 1299.50)
+        self.assertEqual(producto["precio_original"], 1499.0)
+        self.assertEqual(producto["link"], "https://www.temu.com/pe/item-premium")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- sanitize Temu price parsing by stripping currency symbols/thousand separators and centralizing float conversion
- normalize original price handling using the same helper
- add tests covering currency symbols and thousand separators to ensure products are retained

## Testing
- pytest tests/test_temu_scraper.py

------
https://chatgpt.com/codex/tasks/task_e_68d9724de7888332afa6bf32585f33e3