### PR TITLE
Fix AliExpress scraper card retention

### DIFF
--- a/scraper/aliexpress_scraper.py
+++ b/scraper/aliexpress_scraper.py
@@ -315,7 +315,14 @@ class AliExpressScraper(BaseScraper):
                     bloques = self._find_all_any(containers, timeout=6)
 
                 self._human_scroll_until_growth(max_scrolls=10, pause=1.0)
-                bloques = self._find_all_any(containers, timeout=4)
+                nuevos_bloques = self._find_all_any(containers, timeout=4)
+                if nuevos_bloques:
+                    if bloques:
+                        for bloque in nuevos_bloques:
+                            if bloque not in bloques:
+                                bloques.append(bloque)
+                    else:
+                        bloques = nuevos_bloques
                 logging.info("Página %s: %s productos (candidatos)", page, len(bloques))
 
                 # Extrae con Selenium

--- a/tests/test_aliexpress_scraper.py
+++ b/tests/test_aliexpress_scraper.py
@@ -26,6 +26,38 @@ class TestAliExpressScraper(unittest.TestCase):
         )
         mock_driver.get.assert_called_with(expected_url)
 
+    @patch("scraper.aliexpress_scraper.BaseScraper.__init__", return_value=None)
+    def test_preserves_cards_when_final_search_empty(self, mock_base_init):
+        scraper = AliExpressScraper()
+        mock_driver = MagicMock()
+        mock_driver.current_url = "https://es.aliexpress.com/"
+        scraper.driver = mock_driver
+
+        scraper.wait_ready = MagicMock()
+        scraper._accept_banners = MagicMock()
+        scraper._human_scroll_until_growth = MagicMock()
+        scraper._is_blocked = MagicMock(return_value=False)
+        scraper.close = MagicMock()
+
+        card_element = MagicMock(name="card")
+        card_data = {
+            "titulo": "Producto",
+            "precio": 10.0,
+            "precio_original": None,
+            "descuento": None,
+            "ventas": 5,
+            "link": "https://example.com/item",
+        }
+
+        with patch.object(scraper, "_find_all_any", side_effect=[[card_element], []]) as mock_find_all, \
+             patch.object(scraper, "_extract_card", return_value=card_data) as mock_extract:
+            resultados = scraper.parse("producto", paginas=1)
+
+        self.assertEqual(mock_find_all.call_count, 2)
+        mock_extract.assert_called_once_with(card_element)
+        self.assertEqual(len(resultados), 1)
+        self.assertEqual(resultados[0]["titulo"], "Producto")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- prevent the final container search from clearing previously located cards in the AliExpress scraper
- add a regression test that simulates an empty second search to ensure cards are still processed

## Testing
- pytest tests/test_aliexpress_scraper.py

------
https://chatgpt.com/codex/tasks/task_e_68d974be2ad88332a52bce3ae9bf18ba