### PR TITLE
Handle English sold texts in AliExpress scraper

### DIFF
--- a/tests/test_aliexpress_sales.py
+++ b/tests/test_aliexpress_sales.py
@@ -11,3 +11,11 @@ def test_limpiar_cantidad_mil():
 
 def test_limpiar_cantidad_simple():
     assert limpiar_cantidad("450") == 450
+
+
+def test_limpiar_cantidad_english_sold():
+    assert limpiar_cantidad("14 sold") == 14
+
+
+def test_limpiar_cantidad_english_sold_plus():
+    assert limpiar_cantidad("1,000+ sold") == 1000


### PR DESCRIPTION
## Summary
- expand the list of sold selectors with mobile-specific classes and prioritize trimming the captured text
- allow the sold-count regex fallback to match English "sold" labels and reuse the selectors in the BeautifulSoup fallback
- add unit tests that confirm English sold strings are converted into non-zero integers

## Testing
- pytest tests/test_aliexpress_sales.py


------
https://chatgpt.com/codex/tasks/task_e_68d988628408833299c531f47b16ba69