### PR TITLE
Refine AliExpress anti-bot detection

### DIFF
--- a/tests/test_aliexpress_scraper.py
+++ b/tests/test_aliexpress_scraper.py
@@ -184,6 +184,25 @@ class TestAliExpressScraper(unittest.TestCase):
 
         self.assertAlmostEqual(precio, 1234.56)
 
+    @patch("scraper.aliexpress_scraper.BaseScraper.__init__", return_value=None)
+    def test_is_blocked_ignores_meta_robots(self, mock_base_init):
+        scraper = AliExpressScraper()
+        mock_driver = MagicMock()
+        mock_driver.current_url = "https://es.aliexpress.com/item"
+        mock_driver.page_source = """
+        <html>
+            <head>
+                <meta name="robots" content="noindex, nofollow" />
+                <title>Producto regular</title>
+            </head>
+            <body>
+                <div>Contenido disponible sin captcha.</div>
+            </body>
+        </html>
+        """
+
+        self.assertFalse(scraper._is_blocked(mock_driver))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- replace the generic `robot` block pattern with more specific verification phrases and ignore `<meta name="robots">` content when detecting blocks
- tighten `_is_blocked` so it only reports a block when verification text or captcha markers are present
- add a regression test ensuring `_is_blocked` stays false for normal pages that only include `<meta name="robots">`

## Testing
- pytest tests/test_aliexpress_scraper.py::TestAliExpressScraper::test_is_blocked_ignores_meta_robots


------
https://chatgpt.com/codex/tasks/task_e_68d98de0faa883328f970a9b1de7f51d