### PR TITLE
Handle price ranges when normalizing AliExpress prices

### DIFF
--- a/tests/test_aliexpress_price.py
+++ b/tests/test_aliexpress_price.py
@@ -3,3 +3,15 @@ from scraper.aliexpress_scraper import limpiar_precio
 
 def test_limpiar_precio_con_separador_miles():
     assert limpiar_precio("1.299,00") == 1299.00
+
+
+def test_limpiar_precio_con_rango_decimal_punto():
+    assert limpiar_precio("US $7.99 - 15.99") == 7.99
+
+
+def test_limpiar_precio_con_rango_decimal_coma():
+    assert limpiar_precio("€ 12,34 - 56,78") == 12.34
+
+
+def test_limpiar_precio_toma_extremo_inferior():
+    assert limpiar_precio("€56,78 - 12,34") == 12.34


### PR DESCRIPTION
## Summary
- detect hyphenated price ranges in the AliExpress scraper and normalize the lowest amount
- reuse the existing numeric cleaning logic after selecting the minimum range endpoint
- add unit tests to cover price ranges with both dot and comma decimal separators

## Testing
- pytest tests/test_aliexpress_price.py

------
https://chatgpt.com/codex/tasks/task_e_68d99947e4048332b121fdc0f3b9b0f0