### PR TITLE
chore: document persistent selenium profiles and ignore in docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+selenium-profiles/
+cache/
+__pycache__/
+*.pyc
+.pytest_cache/
+.env

--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ Para evitar problemas de compatibilidad, puedes ejecutar el proyecto con Docker 
 docker-compose up --build
 ```
 
+Los perfiles persistentes de Selenium se montan como volúmenes en tiempo de
+ejecución (consulta `docker-compose.yml`). Esto permite reutilizar cookies y
+sesiones sin reconstruir la imagen. Por este motivo, la carpeta local
+`selenium-profiles/` se ignora en la construcción (`.dockerignore`) y no debe
+copiarse dentro de la imagen.
+
 ### Variables de entorno
 
 Antes de iniciar la aplicación o los workers, define las siguientes variables de entorno:


### PR DESCRIPTION
## Summary
- add a `.dockerignore` file so persistent Selenium profiles and other generated artifacts are not copied into the image during `COPY . .`
- document in the README that Selenium profiles are mounted as a runtime volume and should stay outside the built image

## Testing
- not run (Docker is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d9ab9ad2a48332a94122bb69befe15